### PR TITLE
Fix QSortFilterProxyModel object has no attribute setLayerTreeNodeFont

### DIFF
--- a/customtreemodel.py
+++ b/customtreemodel.py
@@ -57,7 +57,7 @@ def pixmapForLegendNode(legend_node):
         return
 
     # Compute minimum width
-    model = iface.layerTreeView().model()
+    model = iface.layerTreeView().layerTreeModel()
     if not legend_node.layerNode():
         return
 

--- a/customtreemodel.py
+++ b/customtreemodel.py
@@ -9,6 +9,7 @@ from PyQt5.QtCore import (
 from PyQt5.QtGui import QIcon, QPixmap, QPainter, QFontMetricsF, QColor
 
 from qgis.core import (
+    Qgis,
     QgsProject,
     QgsLayerTreeModel,
     QgsLayerTree,
@@ -57,7 +58,11 @@ def pixmapForLegendNode(legend_node):
         return
 
     # Compute minimum width
-    model = iface.layerTreeView().layerTreeModel()
+    if Qgis.QGIS_VERSION_INT >= 31800:
+        layer_tree_model = iface.layerTreeView().layerTreeModel()
+    else:
+        layer_tree_model = iface.layerTreeView().model()
+
     if not legend_node.layerNode():
         return
 
@@ -66,7 +71,7 @@ def pixmapForLegendNode(legend_node):
     minimum_width = max(
         max(
             l_node.minimumIconSize().width() + (8 if text else 0)
-            for l_node in model.layerLegendNodes(legend_node.layerNode())
+            for l_node in layer_tree_model.layerLegendNodes(legend_node.layerNode())
             if isinstance(l_node, QgsSymbolLegendNode)
         ),
         size.width(),

--- a/defaulticonsdialog.py
+++ b/defaulticonsdialog.py
@@ -131,13 +131,14 @@ class DefaultIconsDialog(QDialog):
             action_reset.triggered.connect(partial(self.reset, settings_key))
             button.addAction(action_reset)
 
+        self.set_layer_tree_model()
         f = QFont()
         if f.fromString(self.settings.value("group_font")) and f.family():
-            iface.layerTreeView().layerTreeModel().setLayerTreeNodeFont(
+            layer_tree_model.setLayerTreeNodeFont(
                 QgsLayerTree.NodeGroup, f
             )
         else:
-            iface.layerTreeView().layerTreeModel().setLayerTreeNodeFont(
+            layer_tree_model.setLayerTreeNodeFont(
                 QgsLayerTree.NodeGroup, iface.layerTreeView().font()
             )
             self.settings.setValue(
@@ -146,13 +147,13 @@ class DefaultIconsDialog(QDialog):
 
         f = QFont()
         if f.fromString(self.settings.value("layer_font")) and f.family():
-            iface.layerTreeView().layerTreeModel().setLayerTreeNodeFont(
+            layer_tree_model.setLayerTreeNodeFont(
                 QgsLayerTree.NodeLayer, f
             )
         else:
             f = iface.layerTreeView().font()
             f.setBold(True)
-            iface.layerTreeView().layerTreeModel().setLayerTreeNodeFont(
+            layer_tree_model.setLayerTreeNodeFont(
                 QgsLayerTree.NodeLayer, f
             )
             self.settings.setValue("layer_font", f.toString())
@@ -203,9 +204,9 @@ class DefaultIconsDialog(QDialog):
         f.setBold(True)
         self.settings.setValue(f"layer_font", f.toString())
         f = iface.layerTreeView().font()
-        iface.layerTreeView().model().setLayerTreeNodeFont(QgsLayerTree.NodeGroup, f)
+        layer_tree_model.setLayerTreeNodeFont(QgsLayerTree.NodeGroup, f)
         f.setBold(True)
-        iface.layerTreeView().layerTreeModel().setLayerTreeNodeFont(QgsLayerTree.NodeLayer, f)
+        layer_tree_model.setLayerTreeNodeFont(QgsLayerTree.NodeLayer, f)
         self.settings.setValue(f"layer_text_color", "")
         self.settings.setValue(f"layer_background_color", "")
         self.update_font_labels()
@@ -253,7 +254,7 @@ class DefaultIconsDialog(QDialog):
         f.fromString(self.settings.value("layer_font"))
         dialog.setCurrentFont(f)
 
-        f = iface.layerTreeView().layerTreeModel().layerTreeNodeFont(QgsLayerTree.NodeLayer)
+        f = layer_tree_model.layerTreeNodeFont(QgsLayerTree.NodeLayer)
         dialog.setCurrentFont(f)
         if self.settings.value("layer_text_color"):
             dialog.setTextColor(QColor(self.settings.value("layer_text_color")))
@@ -279,7 +280,7 @@ class DefaultIconsDialog(QDialog):
 
     def update_font_labels(self):
         layer_font = (
-            iface.layerTreeView().layerTreeModel().layerTreeNodeFont(QgsLayerTree.NodeLayer)
+            layer_tree_model.layerTreeNodeFont(QgsLayerTree.NodeLayer)
         )
         self.layer_font_label.setText(
             f"{layer_font.family()}, {layer_font.pointSize()}"
@@ -296,7 +297,7 @@ class DefaultIconsDialog(QDialog):
         )
 
         group_font = (
-            iface.layerTreeView().layerTreeModel().layerTreeNodeFont(QgsLayerTree.NodeGroup)
+            layer_tree_model.layerTreeNodeFont(QgsLayerTree.NodeGroup)
         )
         self.group_font_label.setText(
             f"{group_font.family()}, {group_font.pointSize()}"
@@ -311,3 +312,12 @@ class DefaultIconsDialog(QDialog):
             f"color:{text_color}; background-color:{background_color}"
         )
 
+    def set_layer_tree_model(self):
+        global layer_tree_model
+
+        if Qgis.QGIS_VERSION_INT >= 31800:
+            layer_tree_model = iface.layerTreeView().layerTreeModel()
+        else:
+            layer_tree_model = iface.layerTreeView().model()
+
+        return layer_tree_model

--- a/defaulticonsdialog.py
+++ b/defaulticonsdialog.py
@@ -133,11 +133,11 @@ class DefaultIconsDialog(QDialog):
 
         f = QFont()
         if f.fromString(self.settings.value("group_font")) and f.family():
-            iface.layerTreeView().model().setLayerTreeNodeFont(
+            iface.layerTreeView().layerTreeModel().setLayerTreeNodeFont(
                 QgsLayerTree.NodeGroup, f
             )
         else:
-            iface.layerTreeView().model().setLayerTreeNodeFont(
+            iface.layerTreeView().layerTreeModel().setLayerTreeNodeFont(
                 QgsLayerTree.NodeGroup, iface.layerTreeView().font()
             )
             self.settings.setValue(
@@ -146,13 +146,13 @@ class DefaultIconsDialog(QDialog):
 
         f = QFont()
         if f.fromString(self.settings.value("layer_font")) and f.family():
-            iface.layerTreeView().model().setLayerTreeNodeFont(
+            iface.layerTreeView().layerTreeModel().setLayerTreeNodeFont(
                 QgsLayerTree.NodeLayer, f
             )
         else:
             f = iface.layerTreeView().font()
             f.setBold(True)
-            iface.layerTreeView().model().setLayerTreeNodeFont(
+            iface.layerTreeView().layerTreeModel().setLayerTreeNodeFont(
                 QgsLayerTree.NodeLayer, f
             )
             self.settings.setValue("layer_font", f.toString())
@@ -205,7 +205,7 @@ class DefaultIconsDialog(QDialog):
         f = iface.layerTreeView().font()
         iface.layerTreeView().model().setLayerTreeNodeFont(QgsLayerTree.NodeGroup, f)
         f.setBold(True)
-        iface.layerTreeView().model().setLayerTreeNodeFont(QgsLayerTree.NodeLayer, f)
+        iface.layerTreeView().layerTreeModel().setLayerTreeNodeFont(QgsLayerTree.NodeLayer, f)
         self.settings.setValue(f"layer_text_color", "")
         self.settings.setValue(f"layer_background_color", "")
         self.update_font_labels()
@@ -235,7 +235,7 @@ class DefaultIconsDialog(QDialog):
         if res != QDialog.Accepted:
             return
 
-        iface.layerTreeView().model().setLayerTreeNodeFont(
+        iface.layerTreeView().layerTreeModel().setLayerTreeNodeFont(
             QgsLayerTree.NodeGroup, dialog.currentFont()
         )
         self.settings.setValue(f"group_font", dialog.currentFont().toString())
@@ -253,7 +253,7 @@ class DefaultIconsDialog(QDialog):
         f.fromString(self.settings.value("layer_font"))
         dialog.setCurrentFont(f)
 
-        f = iface.layerTreeView().model().layerTreeNodeFont(QgsLayerTree.NodeLayer)
+        f = iface.layerTreeView().layerTreeModel().layerTreeNodeFont(QgsLayerTree.NodeLayer)
         dialog.setCurrentFont(f)
         if self.settings.value("layer_text_color"):
             dialog.setTextColor(QColor(self.settings.value("layer_text_color")))
@@ -266,7 +266,7 @@ class DefaultIconsDialog(QDialog):
         if res != QDialog.Accepted:
             return
 
-        iface.layerTreeView().model().setLayerTreeNodeFont(
+        iface.layerTreeView().layerTreeModel().setLayerTreeNodeFont(
             QgsLayerTree.NodeLayer, dialog.currentFont()
         )
         self.settings.setValue(f"layer_font", dialog.currentFont().toString())
@@ -279,7 +279,7 @@ class DefaultIconsDialog(QDialog):
 
     def update_font_labels(self):
         layer_font = (
-            iface.layerTreeView().model().layerTreeNodeFont(QgsLayerTree.NodeLayer)
+            iface.layerTreeView().layerTreeModel().layerTreeNodeFont(QgsLayerTree.NodeLayer)
         )
         self.layer_font_label.setText(
             f"{layer_font.family()}, {layer_font.pointSize()}"
@@ -296,7 +296,7 @@ class DefaultIconsDialog(QDialog):
         )
 
         group_font = (
-            iface.layerTreeView().model().layerTreeNodeFont(QgsLayerTree.NodeGroup)
+            iface.layerTreeView().layerTreeModel().layerTreeNodeFont(QgsLayerTree.NodeGroup)
         )
         self.group_font_label.setText(
             f"{group_font.family()}, {group_font.pointSize()}"

--- a/menuprovider.py
+++ b/menuprovider.py
@@ -101,7 +101,7 @@ class LayerTreeMenuProvider(QObject):
         """ Set a custom icon as a custom property on the selected nodes """
         dialog = ColorFontDialog(iface.mainWindow())
 
-        f = iface.layerTreeView().model().layerTreeNodeFont(QgsLayerTree.NodeLayer)
+        f = iface.layerTreeView().layerTreeModel().layerTreeNodeFont(QgsLayerTree.NodeLayer)
 
         for node in self.nodes:
             if node.customProperty("plugins/customTreeIcon/font"):

--- a/menuprovider.py
+++ b/menuprovider.py
@@ -5,7 +5,7 @@ from PyQt5.QtWidgets import QAction, QDialog, QFileDialog
 from PyQt5.QtGui import QIcon, QColor
 
 from qgis.utils import iface
-from qgis.core import QgsLayerTree
+from qgis.core import QgsLayerTree, Qgis
 
 from .resourcebrowserimpl import ResourceBrowser
 from .colorfontdialog import ColorFontDialog
@@ -101,7 +101,12 @@ class LayerTreeMenuProvider(QObject):
         """ Set a custom icon as a custom property on the selected nodes """
         dialog = ColorFontDialog(iface.mainWindow())
 
-        f = iface.layerTreeView().layerTreeModel().layerTreeNodeFont(QgsLayerTree.NodeLayer)
+        if Qgis.QGIS_VERSION_INT >= 31800:
+            layer_tree_model = iface.layerTreeView().layerTreeModel()
+        else:
+            layer_tree_model = iface.layerTreeView().model()
+
+        f = layer_tree_model.layerTreeNodeFont(QgsLayerTree.NodeLayer)
 
         for node in self.nodes:
             if node.customProperty("plugins/customTreeIcon/font"):


### PR DESCRIPTION
That issue prevents the plugin installation and crashes QGIS >=3.18 (Fixes #7)
I'm not a pythonista nor a user so I might miss some tests I should do but from a quick glance it loads now and works. Just wanted to address @Francis33 request